### PR TITLE
Fixed spelling of "losses" in Baguette and Covert themes

### DIFF
--- a/Baguette/config.json
+++ b/Baguette/config.json
@@ -122,7 +122,7 @@
 		{
 			"name":			"loss_name",
 			"type":			"text",
-			"value":		"Looses",
+			"value":		"Losses",
 			"x":			435,
 			"y":			51,
 			"align":		"center",

--- a/Covert/config.json
+++ b/Covert/config.json
@@ -121,7 +121,7 @@
 		{
 			"name":			"loss_name",
 			"type":			"text",
-			"value":		"Looses",
+			"value":		"Losses",
 			"x":			315,
 			"y":			35,
 			"align":		"center",


### PR DESCRIPTION
The accompanying screenshots need to be updated too.